### PR TITLE
Enhance site styling

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,12 +1,14 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
+  --background-start: #f8fafc;
+  --background-end: #e0f2fe;
   --foreground: #171717;
+  --accent: #2563eb;
 }
 
 @theme inline {
-  --color-background: var(--background);
+  --color-background: var(--background-start);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
@@ -14,13 +16,27 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
+    --background-start: #1e293b;
+    --background-end: #0f172a;
     --foreground: #ededed;
+    --accent: #60a5fa;
   }
 }
 
 body {
-  background: var(--background);
+  background: linear-gradient(
+    to bottom right,
+    var(--background-start),
+    var(--background-end)
+  );
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
+}
+
+a {
+  color: var(--accent);
+}
+
+a:hover {
+  text-decoration: underline;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -34,9 +34,11 @@ export default async function Home() {
   ];
 
   return (
-    <main className="container mx-auto max-w-3xl p-8 space-y-16">
+    <main className="container mx-auto max-w-3xl p-8 space-y-16 bg-white/70 dark:bg-gray-900/60 rounded-xl shadow-xl backdrop-blur">
       <section className="text-center space-y-4">
-        <h1 className="text-4xl font-bold">Oliver Huth</h1>
+        <h1 className="text-4xl font-bold" style={{ color: "var(--accent)" }}>
+          Oliver Huth
+        </h1>
         <Image
           src="https://placekitten.com/400/400"
           alt="Profile picture"
@@ -56,7 +58,7 @@ export default async function Home() {
           {posts.length === 0 && <li>No posts found.</li>}
           {posts.map((post) => (
             <li key={post.link}>
-              <a href={post.link} className="text-blue-600 hover:underline">
+              <a href={post.link} className="hover:underline">
                 {post.title}
               </a>
             </li>
@@ -69,7 +71,7 @@ export default async function Home() {
         <ul className="list-disc list-inside space-y-2">
           {projects.map((project) => (
             <li key={project.link}>
-              <a href={project.link} className="text-blue-600 hover:underline">
+              <a href={project.link} className="hover:underline">
                 {project.name}
               </a>
             </li>


### PR DESCRIPTION
## Summary
- add a soft gradient background and accent color theme
- style anchor links with the accent color
- wrap page content in a card-like container

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684259f6d4bc83258e2531f31d2cb3bb